### PR TITLE
feat: add auth ui

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,0 +1,13 @@
+interface AuthLayoutProps {
+  children?: React.ReactNode
+}
+
+const AuthLayout = ({ children }: AuthLayoutProps) => {
+  return (
+    <div className='bg-muted flex min-h-svh flex-col items-center justify-center p-6 md:p-10'>
+      <div className='w-full max-w-sm md:max-w-3xl'>{children}</div>
+    </div>
+  )
+}
+
+export default AuthLayout

--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -1,0 +1,5 @@
+import { SignInView } from '@/components/auth/views'
+
+export default function SignInPage() {
+  return <SignInView />
+}

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -1,0 +1,5 @@
+import { SignUpView } from '@/components/auth/views'
+
+export default function SignUpPage() {
+  return <SignUpView />
+}

--- a/components/auth/views/index.ts
+++ b/components/auth/views/index.ts
@@ -1,0 +1,2 @@
+export * from './sign-in-view'
+export * from './sign-up-view'

--- a/components/auth/views/sign-in-view.tsx
+++ b/components/auth/views/sign-in-view.tsx
@@ -1,0 +1,206 @@
+'use client'
+
+import { useState } from 'react'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+
+import { OctagonAlertIcon } from 'lucide-react'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+import { authClient } from '@/lib/auth-client'
+
+import { Alert, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+const formSchema = z.object({
+  email: z.string().email('Correo electrónico inválido'),
+  password: z.string().min(1, 'La contraseña debe tener al menos 1 carácter')
+})
+
+const SignInView = () => {
+  const router = useRouter()
+
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, setIsPending] = useState(false)
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      email: '',
+      password: ''
+    }
+  })
+
+  const onSubmit = (data: z.infer<typeof formSchema>) => {
+    setError(null)
+    setIsPending(true)
+
+    authClient.signIn.email(
+      {
+        email: data.email,
+        password: data.password
+      },
+      {
+        onSuccess: () => {
+          router.push('/')
+        },
+        onError: error => {
+          console.log(error)
+
+          setError(error.error.message)
+        },
+        onResponse: () => {
+          setIsPending(false)
+        }
+      }
+    )
+  }
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <Card className='overflow-hidden p-0'>
+        <CardContent className='grid p-0 md:grid-cols-2'>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className='p-6 lg:p-8'>
+              <div className='flex flex-col gap-6'>
+                <div className='flex flex-col items-center text-center'>
+                  <h1 className='text-2xl font-bold'>Bienvenido de nuevo</h1>
+                  <p className='text-muted-foreground text-xs text-balance'>
+                    Ingresa tus credenciales para continuar
+                  </p>
+                </div>
+
+                <div className='grid gap-3'>
+                  <FormField
+                    control={form.control}
+                    name='email'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Email</FormLabel>
+
+                        <FormControl>
+                          <Input
+                            type='email'
+                            placeholder='m@gmail.com'
+                            {...field}
+                          />
+                        </FormControl>
+
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <div className='grid gap-3'>
+                  <FormField
+                    control={form.control}
+                    name='password'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Contraseña</FormLabel>
+
+                        <FormControl>
+                          <Input
+                            type='password'
+                            placeholder='********'
+                            {...field}
+                          />
+                        </FormControl>
+
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                {!!error && (
+                  <Alert className='bg-destructive/10 border-none'>
+                    <OctagonAlertIcon className='!text-destructive size-4' />
+
+                    <AlertTitle>{error}</AlertTitle>
+                  </Alert>
+                )}
+
+                <Button type='submit' className='w-full' disabled={isPending}>
+                  {isPending ? 'Iniciando sesión...' : 'Iniciar sesión'}
+                </Button>
+
+                <div className='after:border-border relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t'>
+                  <span className='bg-card text-muted-foreground relative z-10 px-2'>
+                    o continúa con
+                  </span>
+                </div>
+
+                <div className='grid grid-cols-2 gap-4'>
+                  <Button
+                    variant='outline'
+                    type='button'
+                    className='w-full'
+                    disabled={isPending}
+                  >
+                    Google
+                  </Button>
+
+                  <Button
+                    variant='outline'
+                    type='button'
+                    className='w-full'
+                    disabled={isPending}
+                  >
+                    Github
+                  </Button>
+                </div>
+
+                <div className='text-muted-foreground text-center text-sm'>
+                  <p>¿No tienes una cuenta?</p>
+                  <Link
+                    href='/sign-up'
+                    className='font-semibold text-emerald-600 underline-offset-4 hover:underline'
+                  >
+                    Regístrate
+                  </Link>
+                </div>
+              </div>
+            </form>
+          </Form>
+
+          <div className='relative hidden flex-col items-center justify-center gap-y-4 bg-radial from-emerald-700 to-emerald-900 md:flex'>
+            <Image src='./logo.svg' alt='Meet AI' width={64} height={64} />
+            <p className='text-2xl font-semibold text-white'>BlockITO</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className='text-muted-foreground *:[a]:hover:text-primary text-center text-sm text-balance *:[a]:underline *:[a]:underline-offset-4'>
+        <p>
+          Al iniciar sesión, aceptas nuestros{' '}
+          <Link href='/terms' className='font-semibold'>
+            Términos de Servicio
+          </Link>{' '}
+          y{' '}
+          <Link href='/privacy' className='font-semibold'>
+            Política de Privacidad
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export { SignInView }

--- a/components/auth/views/sign-up-view.tsx
+++ b/components/auth/views/sign-up-view.tsx
@@ -1,0 +1,229 @@
+'use client'
+
+import { useState } from 'react'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+
+import { OctagonAlertIcon } from 'lucide-react'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+import { authClient } from '@/lib/auth-client'
+
+import { Alert, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+const formSchema = z.object({
+  name: z.string().min(1, 'El nombre es obligatorio'),
+  email: z.string().email('Correo electrónico inválido'),
+  password: z.string().min(1, 'La contraseña debe tener al menos 1 carácter')
+})
+
+export const SignUpView = () => {
+  const router = useRouter()
+
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, setIsPending] = useState(false)
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: '',
+      email: '',
+      password: ''
+    }
+  })
+
+  const onSubmit = (data: z.infer<typeof formSchema>) => {
+    setError(null)
+    setIsPending(true)
+
+    authClient.signUp.email(
+      {
+        name: data.name,
+        email: data.email,
+        password: data.password
+      },
+      {
+        onSuccess: () => {
+          router.push('/')
+        },
+        onError: ({ error }) => {
+          setError(error.message)
+          setIsPending(false)
+        },
+        onResponse: () => {
+          setIsPending(false)
+        }
+      }
+    )
+  }
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <Card className='overflow-hidden p-0'>
+        <CardContent className='grid p-0 md:grid-cols-2'>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className='p-6 lg:p-8'>
+              <div className='flex flex-col gap-6'>
+                <div className='flex flex-col items-center text-center'>
+                  <h1 className='text-2xl font-bold'>Inicia tu aventura</h1>
+                  <p className='text-muted-foreground text-xs text-balance'>
+                    Crea tu cuenta
+                  </p>
+                </div>
+
+                <div className='grid gap-3'>
+                  <FormField
+                    control={form.control}
+                    name='name'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Nombre</FormLabel>
+
+                        <FormControl>
+                          <Input
+                            type='text'
+                            placeholder='Juan Pérez'
+                            autoFocus
+                            {...field}
+                          />
+                        </FormControl>
+
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <div className='grid gap-3'>
+                  <FormField
+                    control={form.control}
+                    name='email'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Email</FormLabel>
+
+                        <FormControl>
+                          <Input
+                            type='email'
+                            placeholder='m@gmail.com'
+                            {...field}
+                          />
+                        </FormControl>
+
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <div className='grid gap-3'>
+                  <FormField
+                    control={form.control}
+                    name='password'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Contraseña</FormLabel>
+
+                        <FormControl>
+                          <Input
+                            type='password'
+                            placeholder='********'
+                            {...field}
+                          />
+                        </FormControl>
+
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                {!!error && (
+                  <Alert className='bg-destructive/10 border-none'>
+                    <OctagonAlertIcon className='!text-destructive size-4' />
+
+                    <AlertTitle>{error}</AlertTitle>
+                  </Alert>
+                )}
+
+                <Button type='submit' className='w-full' disabled={isPending}>
+                  {isPending ? 'Creando cuenta...' : 'Crear cuenta'}
+                </Button>
+
+                <div className='after:border-border relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t'>
+                  <span className='bg-card text-muted-foreground relative z-10 px-2'>
+                    o continúa con
+                  </span>
+                </div>
+
+                <div className='grid grid-cols-2 gap-4'>
+                  <Button
+                    variant='outline'
+                    type='button'
+                    className='w-full'
+                    disabled={isPending}
+                  >
+                    Google
+                  </Button>
+
+                  <Button
+                    variant='outline'
+                    type='button'
+                    className='w-full'
+                    disabled={isPending}
+                  >
+                    Github
+                  </Button>
+                </div>
+
+                <div className='text-muted-foreground text-center text-sm'>
+                  <p>¿Ya tienes una cuenta?</p>
+                  <Link
+                    href='/sign-in'
+                    className='font-semibold text-emerald-600 underline-offset-4 hover:underline'
+                  >
+                    Iniciar sesión
+                  </Link>
+                </div>
+              </div>
+            </form>
+          </Form>
+
+          <div className='relative hidden flex-col items-center justify-center gap-y-4 bg-radial from-emerald-700 to-emerald-900 md:flex'>
+            <Image src='./logo.svg' alt='Meet AI' width={64} height={64} />
+            <p className='text-2xl font-semibold text-white'>BlockITO</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className='text-muted-foreground *:[a]:hover:text-primary text-center text-sm text-balance *:[a]:underline *:[a]:underline-offset-4'>
+        <p>
+          Al registrarte, aceptas nuestros{' '}
+          <Link href='/terms' className='font-semibold'>
+            Términos de Servicio
+          </Link>{' '}
+          y{' '}
+          <Link href='/privacy' className='font-semibold'>
+            Política de Privacidad
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
This pull request introduces a new authentication layout and functionality for sign-in and sign-up pages. It creates reusable components for these views and integrates form validation, error handling, and navigation logic. Below are the most important changes grouped by theme.

### Authentication Layout and Pages:

- **`app/(auth)/layout.tsx`:** Added a new `AuthLayout` component to provide a consistent layout for authentication pages, including responsive design and centralized content.
- **`app/(auth)/sign-in/page.tsx` and `app/(auth)/sign-up/page.tsx`:** Created sign-in and sign-up pages that use the respective views (`SignInView` and `SignUpView`) for rendering. [[1]](diffhunk://#diff-4767fdcb2df42aa595b07e67bbb966b44215c0afb7a0288f0789e951b6e55d04R1-R5) [[2]](diffhunk://#diff-acba130cd5b71be3669db1d617c88c729d316722c508dff646eda3474b2b2a31R1-R5)

### Reusable Authentication Views:

- **`components/auth/views/index.ts`:** Exported `SignInView` and `SignUpView` components for reuse across the application.
- **`components/auth/views/sign-in-view.tsx`:** Implemented the sign-in view with form validation using `zod` and `react-hook-form`, error handling, and navigation logic for successful login. Includes options for social login and links to sign-up and terms/privacy pages.
- **`components/auth/views/sign-up-view.tsx`:** Developed the sign-up view with similar functionality as the sign-in view, including additional validation for the user's name and navigation on successful account creation.