### PR TITLE
feat: add auth socials

### DIFF
--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -1,5 +1,16 @@
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+import { auth } from '@/lib/auth'
+
 import { SignInView } from '@/components/auth/views'
 
-export default function SignInPage() {
+export default async function SignInPage() {
+  const session = await auth.api.getSession({
+    headers: await headers()
+  })
+
+  if (!!session) redirect('/empleos')
+
   return <SignInView />
 }

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -1,5 +1,16 @@
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+import { auth } from '@/lib/auth'
+
 import { SignUpView } from '@/components/auth/views'
 
-export default function SignUpPage() {
+export default async function SignUpPage() {
+  const session = await auth.api.getSession({
+    headers: await headers()
+  })
+
+  if (!!session) redirect('/empleos')
+
   return <SignUpView />
 }

--- a/components/auth/views/sign-in-view.tsx
+++ b/components/auth/views/sign-in-view.tsx
@@ -10,6 +10,7 @@ import { OctagonAlertIcon } from 'lucide-react'
 
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
+import { FaGithub, FaGoogle } from 'react-icons/fa'
 import { z } from 'zod'
 
 import { authClient } from '@/lib/auth-client'
@@ -53,16 +54,41 @@ const SignInView = () => {
     authClient.signIn.email(
       {
         email: data.email,
-        password: data.password
+        password: data.password,
+        callbackURL: '/empleos'
       },
       {
         onSuccess: () => {
-          router.push('/')
+          router.push('/empleos')
         },
         onError: error => {
           console.log(error)
 
           setError(error.error.message)
+        },
+        onResponse: () => {
+          setIsPending(false)
+        }
+      }
+    )
+  }
+
+  const onSocial = (provider: 'google' | 'github') => {
+    setError(null)
+    setIsPending(true)
+
+    authClient.signIn.social(
+      {
+        provider,
+        callbackURL: '/empleos'
+      },
+      {
+        onSuccess: () => {
+          router.push('/empleos')
+        },
+        onError: ({ error }) => {
+          setError(error.message)
+          setIsPending(false)
         },
         onResponse: () => {
           setIsPending(false)
@@ -130,7 +156,7 @@ const SignInView = () => {
                 </div>
 
                 {!!error && (
-                  <Alert className='bg-destructive/10 border-none'>
+                  <Alert className='bg-destructive/10 border-none text-sm font-semibold'>
                     <OctagonAlertIcon className='!text-destructive size-4' />
 
                     <AlertTitle>{error}</AlertTitle>
@@ -149,20 +175,24 @@ const SignInView = () => {
 
                 <div className='grid grid-cols-2 gap-4'>
                   <Button
-                    variant='outline'
+                    variant='google'
                     type='button'
                     className='w-full'
                     disabled={isPending}
+                    onClick={() => onSocial('google')}
                   >
+                    <FaGoogle className='mr-2 size-4' />
                     Google
                   </Button>
 
                   <Button
-                    variant='outline'
+                    variant='github'
                     type='button'
                     className='w-full'
                     disabled={isPending}
+                    onClick={() => onSocial('github')}
                   >
+                    <FaGithub className='mr-2 size-4' />
                     Github
                   </Button>
                 </div>

--- a/components/auth/views/sign-up-view.tsx
+++ b/components/auth/views/sign-up-view.tsx
@@ -10,6 +10,7 @@ import { OctagonAlertIcon } from 'lucide-react'
 
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
+import { FaGithub, FaGoogle } from 'react-icons/fa'
 import { z } from 'zod'
 
 import { authClient } from '@/lib/auth-client'
@@ -56,11 +57,36 @@ export const SignUpView = () => {
       {
         name: data.name,
         email: data.email,
-        password: data.password
+        password: data.password,
+        callbackURL: '/empleos'
       },
       {
         onSuccess: () => {
-          router.push('/')
+          router.push('/empleos')
+        },
+        onError: ({ error }) => {
+          setError(error.message)
+          setIsPending(false)
+        },
+        onResponse: () => {
+          setIsPending(false)
+        }
+      }
+    )
+  }
+
+  const onSocial = (provider: 'google' | 'github') => {
+    setError(null)
+    setIsPending(true)
+
+    authClient.signIn.social(
+      {
+        provider,
+        callbackURL: '/empleos'
+      },
+      {
+        onSuccess: () => {
+          router.push('/empleos')
         },
         onError: ({ error }) => {
           setError(error.message)
@@ -174,20 +200,24 @@ export const SignUpView = () => {
 
                 <div className='grid grid-cols-2 gap-4'>
                   <Button
-                    variant='outline'
+                    variant='google'
                     type='button'
                     className='w-full'
                     disabled={isPending}
+                    onClick={() => onSocial('google')}
                   >
+                    <FaGoogle className='mr-2 size-4' />
                     Google
                   </Button>
 
                   <Button
-                    variant='outline'
+                    variant='github'
                     type='button'
                     className='w-full'
                     disabled={isPending}
+                    onClick={() => onSocial('github')}
                   >
+                    <FaGithub className='mr-2 size-4' />
                     Github
                   </Button>
                 </div>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -20,7 +20,10 @@ const buttonVariants = cva(
           'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
         ghost:
           'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
-        link: 'text-primary underline-offset-4 hover:underline'
+        link: 'text-primary underline-offset-4 hover:underline',
+        github: 'bg-black text-white shadow-xs hover:bg-black/90',
+        google:
+          'bg-white text-black shadow-xs hover:bg-white/90 border border-input'
       },
       size: {
         default: 'h-9 px-4 py-2 has-[>svg]:px-3',

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -8,6 +8,16 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true
   },
+  socialProviders: {
+    github: {
+      clientId: process.env.GITHUB_CLIENT_ID as string,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET as string
+    },
+    google: {
+      clientId: process.env.GOOGLE_CLIENT_ID as string,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET as string
+    }
+  },
   database: drizzleAdapter(db, {
     provider: 'pg',
     schema: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "react-day-picker": "9.7.0",
         "react-dom": "19.0.0",
         "react-hook-form": "7.57.0",
+        "react-icons": "5.5.0",
         "react-resizable-panels": "3.0.2",
         "recharts": "2.15.3",
         "sonner": "2.0.5",
@@ -9992,6 +9993,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-day-picker": "9.7.0",
     "react-dom": "19.0.0",
     "react-hook-form": "7.57.0",
+    "react-icons": "5.5.0",
     "react-resizable-panels": "3.0.2",
     "recharts": "2.15.3",
     "sonner": "2.0.5",


### PR DESCRIPTION
This pull request introduces enhancements to authentication functionality, including session-based redirects, social login support, and UI updates for sign-in and sign-up views. Additionally, it adds new dependencies and updates button styling for social login buttons.

### Authentication Enhancements:
* `app/(auth)/sign-in/page.tsx` and `app/(auth)/sign-up/page.tsx`: Updated the `SignInPage` and `SignUpPage` components to check for active sessions and redirect authenticated users to `/empleos`. [[1]](diffhunk://#diff-4767fdcb2df42aa595b07e67bbb966b44215c0afb7a0288f0789e951b6e55d04R1-R14) [[2]](diffhunk://#diff-acba130cd5b71be3669db1d617c88c729d316722c508dff646eda3474b2b2a31R1-R14)
* [`lib/auth.ts`](diffhunk://#diff-cd41b427b38a554f9a1a2d2e848e41ddc39bc7d68dba54c1398d7384d6aaf4f7R11-R20): Added configuration for social login providers (GitHub and Google) by integrating client IDs and secrets.

### Social Login Support:
* `components/auth/views/sign-in-view.tsx` and `components/auth/views/sign-up-view.tsx`: Added support for social login (Google and GitHub) with respective callback URLs, error handling, and UI integration. [[1]](diffhunk://#diff-4f52088c23551e8488faa3bd9066fec71df99fbe73ecad7bc133dd376ff16d8aR76-R99) [[2]](diffhunk://#diff-b321cd4f9c9bbf0902db1570a9150a08adf66c01269b8e4454d1cfde20451bbcL59-R89)
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R61): Added `react-icons` dependency for social login button icons.

### UI and Styling Updates:
* [`components/ui/button.tsx`](diffhunk://#diff-2795b661f0806f90ae4821c33bdc2c7615156b270ec45bde4769727f4b6bc748L23-R26): Introduced new variants (`google` and `github`) for social login buttons with distinct styling.
* [`components/auth/views/sign-in-view.tsx`](diffhunk://#diff-4f52088c23551e8488faa3bd9066fec71df99fbe73ecad7bc133dd376ff16d8aL133-R159): Improved error alert styling by adding text formatting for better visibility.